### PR TITLE
Use Scrapy instead of Requests to improve performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '3.5'
+- '3.6'
 install:
 - pip install -e .[dev]
 script:
@@ -23,6 +24,7 @@ deploy:
     username: J-CPelletier
     password:
       secure: r7PRWEgVGMG9YT1V/ccAoE2ppb0XiB7Y/ctNcfQZDy3YvTrSoCvTxlSImuxuqZKXU+x+/KL+q1CyVferYk5Ou2Bvexet9uS7IXj59nEJxLqcNa4AGkZubZOMuhZcIYvvbTJYzH1nTtMunvi36czQpYQ15b12hxJX+aMnca9hKru4h7B2o3mGGwWDlKeM+ZyZ3VYFu6ZHzsKfbfSmOpHzdzSiavTp/9VqwGGPOQykUAhj3QEa2uix4vbBoR8+t0O1m1cCejsRFTlWkUzWLwqW41R5LZoIIO0tFmy+5RVBUITFa8lXS69ByQp12+hacufCb270ZV5EeUhcfpvPKp1yGaYUZelkrJ9JOqiLDlz3mRraLkEpCbNCRVFvV01rDKG4qNozTbUXY5TXCj13yV4s4Sgb/CkqA4XKstrUOMw2heELhUtxCa24MYotltg2ZW95jvM93pHxQxSpmy1kKGrFPAhUG5jIv7IaLXyjN0bo68M7M3RG2ZqBxv+EC09zElzDCKQasDaKKP3/99AWI8vIfqDwwSbh2tKWVUQHIN9Ekbhs4YNwy/jHXLsBsx4AZFeHqisBeYfU+2g98vqZ32YiNuU8jwxD2+dnZw176f4yKl+9ovZnC9aHwvsGxPJ+KYzI3BM/2D3RW576UTscyxCdS16hraH4C85ExJApLctm0+I=
+    distributions: "sdist bdist_wheel"
     on:
       tags: true
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
 - '3.6'
 - '3.7-dev'
 install:
-- sudo apt install python3.6-dev
-- sudo apt install python3.7-dev
 - pip install -e .[dev]
 script:
 - py.test --check-supported-comics --cov=webcomix webcomix/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
 - '3.5'
 install:
 - pip install -r requirements.txt
-- pip install pytest-cov
-- pip install coveralls
 script:
 - py.test --cov=webcomix webcomix/tests
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: python
 python:
 - '3.5'
 - '3.6'
+- '3.7'
 install:
+- apt install python3.6-dev
+- apt install python3.7-dev
 - pip install -e .[dev]
 script:
 - py.test --check-supported-comics --cov=webcomix webcomix/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
 - '3.5'
 install:
-- pip install -r requirements.txt
+- pip install -e .[dev]
 script:
 - py.test --cov=webcomix webcomix/tests
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
 - '3.5'
+- '3.6-dev'
 - '3.6'
-- '3.7'
+- '3.7-dev'
 install:
-- apt install python3.6-dev
-- apt install python3.7-dev
+- sudo apt install python3.6-dev
+- sudo apt install python3.7-dev
 - pip install -e .[dev]
 script:
 - py.test --check-supported-comics --cov=webcomix webcomix/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
 - '3.5'
+- '3.5-dev'
 - '3.6-dev'
-- '3.6'
-- '3.7-dev'
 install:
 - pip install -e .[dev]
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
 - pip install -e .[dev]
 script:
-- py.test --cov=webcomix webcomix/tests
+- py.test --check-supported-comics --cov=webcomix webcomix/tests
 after_success:
 - zip -r webcomix_Mac_Linux.zip webcomix requirements.txt setup.py LICENCE README.md
 - coveralls

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This program is for personal use only. Please be aware that by making the downlo
 1. Install [Python 3](https://www.python.org/downloads/)
 2. Clone this repository and open a terminal in its directory
 3. Download the dependencies by running `pip install -e .[dev]`
-4. Install the command line interface tool in development mode by running `pip install --editable .`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This program is for personal use only. Please be aware that by making the downlo
 
 1. Install [Python 3](https://www.python.org/downloads/)
 2. Clone this repository and open a terminal in its directory
-3. Download the dependencies by running `pip install -r requirements.txt`
+3. Download the dependencies by running `pip install -e .[dev]`
 4. Install the command line interface tool in development mode by running `pip install --editable .`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This program is for personal use only. Please be aware that by making the downlo
 * requests
 * click
 * fake-useragent
+* scrapy
 
 ### Process
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--check-supported-comics", action="store_true", default=False, help="checks if supported comics XPath are still working"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--check-supported-comics"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --check-supported_comics option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-requests
-pytest
-lxml
-click
-fake-useragent
-scrapy
-pytest-mock
-pytest-cov
-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 lxml
 click
 fake-useragent
+scrapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ lxml
 click
 fake-useragent
 scrapy
+pytest-mock
 pytest-cov
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ lxml
 click
 fake-useragent
 scrapy
+pytest-cov
+coveralls

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,13 @@ setup(
         'fake-useragent',
         'scrapy'
     ],
+    extra_requires={
+        'dev': [
+            'pytest',
+            'pytest-cov',
+            'coveralls'
+        ]
+    },
     python_requires='>=3.5',
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'fake-useragent',
         'scrapy'
     ],
-    extra_requires={
+    extras_require={
         'dev': [
             'pytest',
             'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'dev': [
             'pytest',
             'pytest-cov',
+            'pytest-mock',
             'coveralls'
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'Click',
         'lxml',
         'requests',
-        'fake-useragent'
+        'fake-useragent',
+        'scrapy'
     ],
     python_requires='>=3.5',
     entry_points='''

--- a/webcomix/comic.py
+++ b/webcomix/comic.py
@@ -106,46 +106,7 @@ class Comic:
             comic_image_selector=self.comic_image_selector,
             directory=directory_name)
         process.start()
-
-        # url = self.start_url
-        # page = 1
-        # while True:
-        #     click.echo("Downloading page {}".format(url))
-        #     response = requests.get(url, headers=header)
-        #     parsed_html = html.fromstring(response.content)
-
-        #     image_element = parsed_html.xpath(self.comic_image_selector)
-        #     next_link = parsed_html.xpath(self.next_page_selector)
-
-        #     if image_element == []:
-        #         click.echo("Could not find comic image.")
-        #     else:
-        #         try:
-        #             image_url = urljoin(url, image_element[0])
-        #             Comic.save_image(image_url, directory_name, page)
-        #         except:
-        #             click.echo("The image couldn't be downloaded.")
-
-        #     page += 1
-        #     if next_link == [] or next_link[0].endswith("#"):
-        #         break
-        #     url = urljoin(url, next_link[0])
         click.echo("Finished downloading the images.")
-
-    @staticmethod
-    def save_image(image_url: str, directory_name: str, page: int):
-        """
-        Gets the image from the image_url and saves it in the directory_name
-        """
-        click.echo("Saving image {}".format(image_url))
-        res = requests.get(image_url, headers=header)
-        res.raise_for_status()
-        image_path = Comic.save_image_location(image_url, directory_name, page)
-        if os.path.isfile(image_path):
-            click.echo("The image was already downloaded. Skipping...")
-        else:
-            with open(image_path, 'wb') as image_file:
-                image_file.write(res.content)
 
     @staticmethod
     def save_image_location(url: str, page: int, directory_name: str = ''):

--- a/webcomix/comic.py
+++ b/webcomix/comic.py
@@ -36,7 +36,8 @@ class Comic:
                 'scrapy.pipelines.images.ImagesPipeline': 1
             },
             'LOG_ENABLED': False,
-            'IMAGES_STORE': directory_name
+            'IMAGES_STORE': directory_name,
+            'MEDIA_ALLOW_REDIRECTS': True
         })
         process.crawl(
             ComicSpider,

--- a/webcomix/comic.py
+++ b/webcomix/comic.py
@@ -1,6 +1,6 @@
 import os
 from urllib.parse import urljoin
-from zipfile import ZipFile
+from zipfile import ZipFile, BadZipFile
 
 import click
 import requests
@@ -78,7 +78,7 @@ class Comic:
                 os.remove(image_location)
             os.rmdir(source_directory)
             if cbz_file.testzip() is not None:
-                click.echo(
+                raise BadZipFile(
                     "Error while testing the archive; it might be corrupted.")
 
     @staticmethod

--- a/webcomix/comic.py
+++ b/webcomix/comic.py
@@ -33,10 +33,10 @@ class Comic:
         process = CrawlerProcess({
             'ITEM_PIPELINES': {
                 'webcomix.comic_pipeline.ComicPipeline': 500,
-                'scrapy.pipelines.images.ImagesPipeline': 1
+                'scrapy.pipelines.files.FilesPipeline': 1
             },
             'LOG_ENABLED': False,
-            'IMAGES_STORE': directory_name,
+            'FILES_STORE': directory_name,
             'MEDIA_ALLOW_REDIRECTS': True
         })
         process.crawl(

--- a/webcomix/comic.py
+++ b/webcomix/comic.py
@@ -74,7 +74,7 @@ class Comic:
             images = os.listdir(source_directory)
             for image in images:
                 image_location = "{}/{}".format(source_directory, image)
-                cbz_file.write(image_location)
+                cbz_file.write(image_location, image)
                 os.remove(image_location)
             os.rmdir(source_directory)
             if cbz_file.testzip() is not None:

--- a/webcomix/comic_page.py
+++ b/webcomix/comic_page.py
@@ -1,0 +1,6 @@
+import scrapy
+
+
+class ComicPage(scrapy.Item):
+    image_element = scrapy.Field()
+    page = scrapy.Field()

--- a/webcomix/comic_page.py
+++ b/webcomix/comic_page.py
@@ -2,5 +2,5 @@ import scrapy
 
 
 class ComicPage(scrapy.Item):
-    image_element = scrapy.Field()
+    url = scrapy.Field()
     page = scrapy.Field()

--- a/webcomix/comic_pipeline.py
+++ b/webcomix/comic_pipeline.py
@@ -10,17 +10,17 @@ from webcomix.comic import Comic
 
 class ComicPipeline(FilesPipeline):
     def get_media_requests(self, item, info):
-        click.echo("Saving image {}".format(item.get('image_element')))
+        click.echo("Saving image {}".format(item.get('url')))
         image_path = Comic.save_image_location(
-            item.get("image_element"), item.get("page"), info.spider.directory)
+            item.get("url"), item.get("page"), info.spider.directory)
         if os.path.isfile(image_path):
             click.echo("The image was already downloaded. Skipping...")
             raise DropItem("The image was already downloaded. Skipping...")
         yield scrapy.Request(
-            item.get("image_element"),
+            item.get("url"),
             meta={
                 'page': item.get('page'),
-                'image_element': item.get('image_element')
+                'url': item.get('url')
             })
 
     def item_completed(self, results, item, info):
@@ -33,5 +33,5 @@ class ComicPipeline(FilesPipeline):
 
     def file_path(self, request, response=None, info=None):
         path = Comic.save_image_location(
-            request.meta.get("image_element"), request.meta.get("page"))
+            request.meta.get("url"), request.meta.get("page"))
         return path

--- a/webcomix/comic_pipeline.py
+++ b/webcomix/comic_pipeline.py
@@ -3,12 +3,12 @@ import os
 import click
 import scrapy
 from scrapy.exceptions import DropItem
-from scrapy.pipelines.images import ImagesPipeline
+from scrapy.pipelines.images import FilesPipeline
 
 from webcomix.comic import Comic
 
 
-class ComicPipeline(ImagesPipeline):
+class ComicPipeline(FilesPipeline):
     def get_media_requests(self, item, info):
         click.echo("Saving image {}".format(item.get('image_element')))
         image_path = Comic.save_image_location(

--- a/webcomix/comic_pipeline.py
+++ b/webcomix/comic_pipeline.py
@@ -3,7 +3,7 @@ import os
 import click
 import scrapy
 from scrapy.exceptions import DropItem
-from scrapy.pipelines.images import FilesPipeline
+from scrapy.pipelines.files import FilesPipeline
 
 from webcomix.comic import Comic
 

--- a/webcomix/comic_pipeline.py
+++ b/webcomix/comic_pipeline.py
@@ -11,7 +11,6 @@ from webcomix.comic import Comic
 class ComicPipeline(FilesPipeline):
     def get_media_requests(self, item, info):
         click.echo("Saving image {}".format(item.get('url')))
-        print(info)
         image_path = Comic.save_image_location(
             item.get("url"), item.get("page"), info.spider.directory)
         if os.path.isfile(image_path):
@@ -20,7 +19,8 @@ class ComicPipeline(FilesPipeline):
         yield scrapy.Request(
             item.get("url"),
             meta={
-                'image_path': image_path
+                'image_path':
+                Comic.save_image_location(item.get("url"), item.get("page"))
             })
 
     def item_completed(self, results, item, info):

--- a/webcomix/comic_pipeline.py
+++ b/webcomix/comic_pipeline.py
@@ -1,0 +1,37 @@
+import os
+
+import click
+import scrapy
+from scrapy.exceptions import DropItem
+from scrapy.pipelines.images import ImagesPipeline
+
+from webcomix.comic import Comic
+
+
+class ComicPipeline(ImagesPipeline):
+    def get_media_requests(self, item, info):
+        click.echo("Saving image {}".format(item.get('image_element')))
+        image_path = Comic.save_image_location(
+            item.get("image_element"), item.get("page"), info.spider.directory)
+        if os.path.isfile(image_path):
+            click.echo("The image was already downloaded. Skipping...")
+            raise DropItem("The image was already downloaded. Skipping...")
+        yield scrapy.Request(
+            item.get("image_element"),
+            meta={
+                'page': item.get('page'),
+                'image_element': item.get('image_element')
+            })
+
+    def item_completed(self, results, item, info):
+        file_paths = [data['path'] for ok, data in results if ok]
+        if not file_paths:
+            click.echo("Could not find comic image.")
+            raise DropItem("Could not find comic image.")
+
+        return item
+
+    def file_path(self, request, response=None, info=None):
+        path = Comic.save_image_location(
+            request.meta.get("image_element"), request.meta.get("page"))
+        return path

--- a/webcomix/comic_pipeline.py
+++ b/webcomix/comic_pipeline.py
@@ -11,6 +11,7 @@ from webcomix.comic import Comic
 class ComicPipeline(FilesPipeline):
     def get_media_requests(self, item, info):
         click.echo("Saving image {}".format(item.get('url')))
+        print(info)
         image_path = Comic.save_image_location(
             item.get("url"), item.get("page"), info.spider.directory)
         if os.path.isfile(image_path):
@@ -19,8 +20,7 @@ class ComicPipeline(FilesPipeline):
         yield scrapy.Request(
             item.get("url"),
             meta={
-                'page': item.get('page'),
-                'url': item.get('url')
+                'image_path': image_path
             })
 
     def item_completed(self, results, item, info):
@@ -32,6 +32,4 @@ class ComicPipeline(FilesPipeline):
         return item
 
     def file_path(self, request, response=None, info=None):
-        path = Comic.save_image_location(
-            request.meta.get("url"), request.meta.get("page"))
-        return path
+        return request.meta.get('image_path')

--- a/webcomix/comic_spider.py
+++ b/webcomix/comic_spider.py
@@ -3,6 +3,8 @@ from urllib.parse import urljoin
 import click
 import scrapy
 
+from webcomix.comic_page import ComicPage
+
 
 class ComicSpider(scrapy.Spider):
     name = "Comic Spider"
@@ -20,10 +22,9 @@ class ComicSpider(scrapy.Spider):
 
         page = response.meta.get('page') or 1
         if comic_image_url is not None:
-            yield {
-                "image_element": urljoin(response.url, comic_image_url),
-                "page": page
-            }
+            yield ComicPage(
+                url=urljoin(response.url, comic_image_url),
+                page=page)
         else:
             click.echo("Could not find comic image.")
         next_page_url = response.xpath(self.next_page_selector).extract_first()

--- a/webcomix/comic_spider.py
+++ b/webcomix/comic_spider.py
@@ -1,10 +1,11 @@
 from urllib.parse import urljoin
 
+import click
 import scrapy
 
 
 class ComicSpider(scrapy.Spider):
-    name = "My spider"
+    name = "Comic Spider"
 
     def __init__(self, *args, **kwargs):
         self.start_urls = kwargs.get('start_urls') or []
@@ -13,14 +14,18 @@ class ComicSpider(scrapy.Spider):
         super(ComicSpider, self).__init__(*args, **kwargs)
 
     def parse(self, response):
+        click.echo("Downloading page {}".format(response.url))
         comic_image_url = response.xpath(
             self.comic_image_selector).extract_first()
 
         page = response.meta.get('page') or 1
-        yield {
-            "image_element": urljoin(response.url, comic_image_url),
-            "page": page
-        }
+        if comic_image_url is not None:
+            yield {
+                "image_element": urljoin(response.url, comic_image_url),
+                "page": page
+            }
+        else:
+            click.echo("Could not find comic image.")
         next_page_url = response.xpath(self.next_page_selector).extract_first()
         if next_page_url is not None and not next_page_url.endswith('#'):
             yield scrapy.Request(

--- a/webcomix/comic_spider.py
+++ b/webcomix/comic_spider.py
@@ -1,0 +1,27 @@
+from urllib.parse import urljoin
+
+import scrapy
+
+
+class ComicSpider(scrapy.Spider):
+    name = "My spider"
+
+    def __init__(self, *args, **kwargs):
+        self.start_urls = kwargs.get('start_urls') or []
+        self.next_page_selector = kwargs.get('next_page_selector', None)
+        self.comic_image_selector = kwargs.get('comic_image_selector', None)
+        super(ComicSpider, self).__init__(*args, **kwargs)
+
+    def parse(self, response):
+        comic_image_url = response.xpath(
+            self.comic_image_selector).extract_first()
+
+        page = response.meta.get('page') or 1
+        yield {
+            "image_element": urljoin(response.url, comic_image_url),
+            "page": page
+        }
+        next_page_url = response.xpath(self.next_page_selector).extract_first()
+        if next_page_url is not None and not next_page_url.endswith('#'):
+            yield scrapy.Request(
+                response.urljoin(next_page_url), meta={'page': page + 1})

--- a/webcomix/supported_comics.py
+++ b/webcomix/supported_comics.py
@@ -2,7 +2,7 @@ supported_comics = {
     "xkcd": ("http://xkcd.com/1/", "//a[@rel='next']/@href", "//div[@id='comic']//img/@src"),
     "Nedroid": ("http://nedroid.com/2005/09/2210-whee/", "//div[@class='nav-next']/a/@href", "//div[@id='comic']/img/@src"),
     "JL8": ("http://limbero.org/jl8/1", "//a[text()='>']/@href", "//img/@src"),
-    "SMBC": ("http://www.smbc-comics.com/comic/2002-09-05", "//a[@class='next']/@href", "//img[@id='cc-comic']/@src"),
+    "SMBC": ("http://www.smbc-comics.com/comic/2002-09-05", "//a[@class='cc-next']/@href", "//img[@id='cc-comic']/@src"),
     "Blindsprings": ("http://www.blindsprings.com/comic/blindsprings-cover-book-one", "//a[@class='cc-next']/@href", "//img[@id='cc-comic']/@src"),
     "TheAbominableCharlesChristopher": ("http://abominable.cc/post/44164796353/episode-one", "//span[@class='next_post']//@href", "//div[@class='photo']//img/@src"),
     "GuildedAge": ("http://guildedage.net/comic/chapter-1-cover/", "//a[@class='navi comic-nav-next navi-next']/@href", "//div[@id='comic']//img/@src"),

--- a/webcomix/tests/test_comic.py
+++ b/webcomix/tests/test_comic.py
@@ -2,8 +2,7 @@ import os
 import shutil
 from urllib.parse import urljoin
 from zipfile import ZipFile
-
-import requests
+import urllib.request
 
 from webcomix.comic import Comic
 from webcomix.supported_comics import supported_comics
@@ -11,9 +10,9 @@ from webcomix.supported_comics import supported_comics
 
 def test_save_image_location():
     assert Comic.save_image_location(
-        "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg", "foo",
-        1) == "foo/1.jpg"
-    assert Comic.save_image_location("", "bar", 1) == "bar/1"
+        "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg", 1,
+        "foo") == "foo/1.jpg"
+    assert Comic.save_image_location("", 1, "bar") == "bar/1"
 
 
 def test_urljoin():
@@ -23,37 +22,6 @@ def test_urljoin():
     assert urljoin("http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg",
                    "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg"
                    ) == "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg"
-
-
-def test_save_image_no_image():
-    comic = Comic("http://xkcd.com/1/", "//a[@rel='next']/@href",
-                  "//div[@id='comic']/img/@src")
-    if os.path.isdir("test"):
-        shutil.rmtree("test")
-    os.makedirs("test")
-    comic.save_image("http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg",
-                     "test", 1)
-    assert os.path.isfile("test/1.jpg")
-    os.remove("test/1.jpg")
-    os.rmdir("test")
-
-
-def test_save_image_already_present(capfd):
-    comic = Comic("http://xkcd.com/1/", "//a[@rel='next']/@href",
-                  "//div[@id='comic']/img/@src")
-    if os.path.isdir("test"):
-        shutil.rmtree("test")
-    os.makedirs("test")
-    with open("test/1.jpg", "w") as image_file:
-        image_file.write("1")
-    comic.save_image("http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg",
-                     "test", 1)
-    out, err = capfd.readouterr()
-    assert out == (
-        "Saving image http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg\n"
-        "The image was already downloaded. Skipping...\n")
-    os.remove("test/1.jpg")
-    os.rmdir("test")
 
 
 def test_make_cbz():
@@ -84,9 +52,9 @@ def test_download():
     comic.download("test")
     for i in range(1, 3):
         with open("test/{}.jpeg".format(i), "rb") as result:
-            expected = requests.get(
+            expected = urllib.request.urlopen(
                 "https://j-cpelletier.github.io/webcomix/{}.jpeg".format(i))
-            assert expected.content == result.read()
+            assert expected.read() == result.read()
     shutil.rmtree("test")
 
 

--- a/webcomix/tests/test_comic.py
+++ b/webcomix/tests/test_comic.py
@@ -1,8 +1,6 @@
-import os
 import shutil
 from urllib.parse import urljoin
 from zipfile import ZipFile
-import urllib.request
 
 from webcomix.comic import Comic
 from webcomix.supported_comics import supported_comics

--- a/webcomix/tests/test_comic.py
+++ b/webcomix/tests/test_comic.py
@@ -24,29 +24,23 @@ def test_urljoin():
                    ) == "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg"
 
 
-def test_make_cbz():
+def test_make_cbz(tmpdir):
     comic = Comic("http://xkcd.com/1/", "//a[@rel='next']/@href",
                   "//div[@id='comic']/img/@src")
-    if os.path.isdir("test"):
-        shutil.rmtree("test")
-    os.makedirs("test")
+    tmpdir.mkdir("test")
     for i in range(1, 6):
-        with open("test/{}.txt".format(i), "w") as image_file:
-            image_file.write("testing {}".format(i))
-    comic.make_cbz("test", "test")
+        image_file = tmpdir.join("test/{}.txt".format(i))
+        image_file.write("testing {}".format(i))
+    comic.make_cbz("test", tmpdir.join("test").strpath)
     with ZipFile("test.cbz") as cbz_file:
+        print(cbz_file.namelist())
         for i in range(1, 6):
-            with cbz_file.open("test/{}.txt".format(i), "r") as image_file:
+            with cbz_file.open("{}.txt".format(i), "r") as image_file:
                 assert str(
                     image_file.read()).strip("b'") == "testing {}".format(i)
-    os.remove("test.cbz")
 
 
 def test_download(mocker):
-    if os.path.isdir("test"):
-        shutil.rmtree("test")
-    if os.path.isfile("test.cbz"):
-        os.remove("test.cbz")
     mock = mocker.patch('webcomix.comic.CrawlerProcess.start')
     comic = Comic("http://xkcd.com/1/", "//a[@rel='next']/@href", "//div[@id='comic']//img/@src")
     comic.download("test")

--- a/webcomix/tests/test_comic.py
+++ b/webcomix/tests/test_comic.py
@@ -42,19 +42,15 @@ def test_make_cbz():
     os.remove("test.cbz")
 
 
-def test_download():
+def test_download(mocker):
     if os.path.isdir("test"):
         shutil.rmtree("test")
     if os.path.isfile("test.cbz"):
         os.remove("test.cbz")
-    comic = Comic("https://j-cpelletier.github.io/webcomix/1.html",
-                  "//a/@href", "//img/@src")
+    mock = mocker.patch('webcomix.comic.CrawlerProcess.start')
+    comic = Comic("http://xkcd.com/1/", "//a[@rel='next']/@href", "//div[@id='comic']//img/@src")
     comic.download("test")
-    for i in range(1, 3):
-        with open("test/{}.jpeg".format(i), "rb") as result:
-            expected = urllib.request.urlopen(
-                "https://j-cpelletier.github.io/webcomix/{}.jpeg".format(i))
-            assert expected.read() == result.read()
+    assert mock.call_count == 1
     shutil.rmtree("test")
 
 

--- a/webcomix/tests/test_comic_pipeline.py
+++ b/webcomix/tests/test_comic_pipeline.py
@@ -1,0 +1,40 @@
+from scrapy.exceptions import DropItem
+import pytest
+
+from webcomix.comic_pipeline import ComicPipeline
+from webcomix.comic_page import ComicPage
+from webcomix.supported_comics import supported_comics
+
+first_comic = list(sorted(supported_comics.values()))[0]
+
+expected_url_image = "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg"
+expected_image_location = "test/1.jpg"
+
+
+def test_comic_pipeline_returns_good_request_when_file_not_present(mocker):
+    file_not_there = mocker.patch('os.path.isfile', return_value=False)
+    spider_info = mocker.patch(
+        'scrapy.pipelines.media.MediaPipeline.SpiderInfo')
+    got_save_image = mocker.patch(
+        'webcomix.comic.Comic.save_image_location',
+        return_value=expected_image_location)
+    pipeline = ComicPipeline(store_uri="foo")
+    elements = list(
+        pipeline.get_media_requests(
+            ComicPage(url=expected_url_image, page=1), spider_info))
+    request = elements[0]
+    assert request.url == expected_url_image
+    assert request.meta['image_path'] == expected_image_location
+
+
+def test_comic_pipeline_drops_item_when_file_present(mocker):
+    file_here = mocker.patch('os.path.isfile', return_value=True)
+    spider_info = mocker.patch(
+        'scrapy.pipelines.media.MediaPipeline.SpiderInfo')
+    got_save_image = mocker.patch(
+        'webcomix.comic.Comic.save_image_location',
+        return_value=expected_image_location)
+    pipeline = ComicPipeline(store_uri="foo")
+    with pytest.raises(DropItem):
+        elements = list(pipeline.get_media_requests(
+            ComicPage(url=expected_url_image, page=1), spider_info))

--- a/webcomix/tests/test_comic_pipeline.py
+++ b/webcomix/tests/test_comic_pipeline.py
@@ -1,4 +1,5 @@
 from scrapy.exceptions import DropItem
+from scrapy.http import Request
 import pytest
 
 from webcomix.comic_pipeline import ComicPipeline
@@ -11,30 +12,58 @@ expected_url_image = "http://imgs.xkcd.com/comics/barrel_cropped_(1).jpg"
 expected_image_location = "test/1.jpg"
 
 
-def test_comic_pipeline_returns_good_request_when_file_not_present(mocker):
-    file_not_there = mocker.patch('os.path.isfile', return_value=False)
-    spider_info = mocker.patch(
+def test_get_media_requests_returns_good_request_when_file_not_present(mocker):
+    mock_file_not_there = mocker.patch('os.path.isfile', return_value=False)
+    mock_spider_info = mocker.patch(
         'scrapy.pipelines.media.MediaPipeline.SpiderInfo')
-    got_save_image = mocker.patch(
+    mock_got_save_image = mocker.patch(
         'webcomix.comic.Comic.save_image_location',
         return_value=expected_image_location)
     pipeline = ComicPipeline(store_uri="foo")
     elements = list(
         pipeline.get_media_requests(
-            ComicPage(url=expected_url_image, page=1), spider_info))
+            ComicPage(url=expected_url_image, page=1), mock_spider_info))
     request = elements[0]
     assert request.url == expected_url_image
     assert request.meta['image_path'] == expected_image_location
 
 
-def test_comic_pipeline_drops_item_when_file_present(mocker):
-    file_here = mocker.patch('os.path.isfile', return_value=True)
-    spider_info = mocker.patch(
+def test_get_media_requests_drops_item_when_file_present(mocker):
+    mock_file_here = mocker.patch('os.path.isfile', return_value=True)
+    mock_spider_info = mocker.patch(
         'scrapy.pipelines.media.MediaPipeline.SpiderInfo')
-    got_save_image = mocker.patch(
+    mock_got_save_image = mocker.patch(
         'webcomix.comic.Comic.save_image_location',
         return_value=expected_image_location)
     pipeline = ComicPipeline(store_uri="foo")
     with pytest.raises(DropItem):
         elements = list(pipeline.get_media_requests(
-            ComicPage(url=expected_url_image, page=1), spider_info))
+            ComicPage(url=expected_url_image, page=1), mock_spider_info))
+
+
+def test_item_completed_returns_item_when_file_downloaded(mocker):
+    results = [(True, {'path': expected_image_location})]
+    item = ComicPage()
+    pipeline = ComicPipeline(store_uri="foo")
+
+    result = pipeline.item_completed(results, item, mocker.ANY)
+
+    assert result == item
+
+
+def test_item_completed_returns_drops_when_file_not_downloaded(mocker):
+    results = [(False, {})]
+    item = ComicPage()
+    pipeline = ComicPipeline(store_uri="foo")
+
+    with pytest.raises(DropItem):
+        pipeline.item_completed(results, item, mocker.ANY)
+
+
+def test_file_path_is_image_path(mocker):
+    mock_request = mocker.patch(
+        'scrapy.http.Request')
+    mock_request.meta = {'image_path': expected_image_location}
+    pipeline = ComicPipeline(store_uri="foo")
+    file_path = pipeline.file_path(mock_request)
+    assert file_path == expected_image_location

--- a/webcomix/tests/test_comic_spider.py
+++ b/webcomix/tests/test_comic_spider.py
@@ -1,0 +1,35 @@
+from webcomix.comic_spider import ComicSpider
+
+
+def test_parse_yields_good_page(mocker):
+    mock_response = mocker.patch('scrapy.http.Response')
+    mock_response.urljoin.return_value = "http://xkcd.com/3/"
+    mock_response.url = "http://xkcd.com/2/"
+    mock_selector = mocker.patch('scrapy.selector.SelectorList')
+    mock_response.xpath.return_value = mock_selector
+    mock_selector.extract_first.side_effect = [
+        '//imgs.xkcd.com/comics/tree_cropped_(1).jpg', 'xkcd.com/3/'
+    ]
+
+    spider = ComicSpider()
+    result = spider.parse(mock_response)
+    results = list(result)
+    assert len(results) == 2
+    assert results[0].get(
+        'url') == "http://imgs.xkcd.com/comics/tree_cropped_(1).jpg"
+    assert results[1].url == "http://xkcd.com/3/"
+
+
+def test_parse_yields_bad_page(mocker):
+    mock_response = mocker.patch('scrapy.http.Response')
+    mock_response.urljoin.return_value = "http://xkcd.com/3/"
+    mock_response.url = "http://xkcd.com/2/"
+    mock_selector = mocker.patch('scrapy.selector.SelectorList')
+    mock_response.xpath.return_value = mock_selector
+    mock_selector.extract_first.side_effect = [None, 'xkcd.com/3/']
+
+    spider = ComicSpider()
+    result = spider.parse(mock_response)
+    results = list(result)
+    assert len(results) == 1
+    assert results[0].url == "http://xkcd.com/3/"

--- a/webcomix/tests/test_main.py
+++ b/webcomix/tests/test_main.py
@@ -118,6 +118,23 @@ def test_search(mocker):
     result = runner.invoke(main.search, ["foo", "--start_url=good"], "y")
     assert result.exit_code == 0
     assert mock_discovery.call_count == 1
-    assert mock_download.call_count == 1
     assert mock_verify_xpath.call_count == 1
     assert mock_print_verification.call_count == 1
+    assert mock_download.call_count == 1
+
+
+def test_search_make_cbz(mocker):
+    runner = CliRunner()
+    mock_discovery = mocker.patch('webcomix.main.discovery', return_value=Comic('url', 'next_page', 'comic_image'))
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
+    mock_verify_xpath = mocker.patch('webcomix.comic.Comic.verify_xpath')
+    mock_print_verification = mocker.patch('webcomix.main.print_verification')
+    mock_make_cbz = mocker.patch('webcomix.comic.Comic.make_cbz')
+
+    result = runner.invoke(main.search, ['foo', '--start_url=good', '--cbz'], 'y')
+    assert result.exit_code == 0
+    assert mock_discovery.call_count == 1
+    assert mock_verify_xpath.call_count == 1
+    assert mock_print_verification.call_count == 1
+    assert mock_download.call_count == 1
+    assert mock_make_cbz.call_count == 1

--- a/webcomix/tests/test_main.py
+++ b/webcomix/tests/test_main.py
@@ -4,6 +4,8 @@ from webcomix import main
 from webcomix.comic import Comic
 from webcomix.supported_comics import supported_comics
 
+first_comic = list(sorted(supported_comics.keys()))[0]
+
 
 def test_print_verification(capfd):
     verification = Comic.verify_xpath(*supported_comics["xkcd"])
@@ -30,115 +32,92 @@ def test_comics():
     assert len(result.output) > 0
 
 
-def mock_download(comic, name):
-    print(name)
-
-
-first_comic = list(sorted(supported_comics.keys()))[0]
-
-
-def test_good_download(monkeypatch):
+def test_good_download_ends_up_downloading(mocker):
     runner = CliRunner()
-    monkeypatch.setattr(Comic, "download", mock_download)
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
 
     result = runner.invoke(main.download, [first_comic])
     assert result.exit_code == 0
-    assert result.output.strip() == first_comic
+    assert mock_download.call_count == 1
 
 
-def test_bad_download(monkeypatch):
+def test_unknown_download_does_nothing(mocker):
     runner = CliRunner()
-    monkeypatch.setattr(Comic, "download", mock_download)
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
 
     result = runner.invoke(main.download, ["foo"])
     assert result.exit_code == 0
-    assert result.output == ""
+    assert mock_download.call_count == 0
 
 
-def mock_make_cbz(comic_class, name, source_directory):
-    print(".cbz created")
-
-
-def test_good_download_makecbz(monkeypatch):
+def test_good_download_makes_the_cbz_file(mocker):
     runner = CliRunner()
-    monkeypatch.setattr(Comic, "download", mock_download)
-    monkeypatch.setattr(Comic, "make_cbz", mock_make_cbz)
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
+    mock_make_cbz = mocker.patch('webcomix.comic.Comic.make_cbz')
 
     result = runner.invoke(main.download, [first_comic, "--cbz"])
     assert result.exit_code == 0
-    assert result.output.strip() == "\n".join([first_comic, ".cbz created"])
+    assert mock_download.call_count == 1
+    assert mock_make_cbz.call_count == 1
 
 
-def test_bad_download_make_cbz(monkeypatch):
+def test_bad_download_does_not_make_the_cbz(mocker):
     runner = CliRunner()
-    monkeypatch.setattr(Comic, "download", mock_download)
-    monkeypatch.setattr(Comic, "make_cbz", mock_make_cbz)
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
+    mock_make_cbz = mocker.patch('webcomix.comic.Comic.make_cbz')
 
     result = runner.invoke(main.download, ["foo", "--cbz"])
     assert result.exit_code == 0
-    assert result.output == ""
+    assert mock_download.call_count == 0
+    assert mock_make_cbz.call_count == 0
 
 
-def mock_verify_xpath(url, next_page, comic_image):
-    print("Verified")
-
-
-def mock_print_verification(validation):
-    print("Printed")
-
-
-def test_custom(monkeypatch):
+def test_custom(mocker):
     runner = CliRunner()
-    monkeypatch.setattr(Comic, "download", mock_download)
-    monkeypatch.setattr(Comic, "verify_xpath", mock_verify_xpath)
-    monkeypatch.setattr(main, "print_verification", mock_print_verification)
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
+    mock_verify_xpath = mocker.patch('webcomix.comic.Comic.verify_xpath')
+    mock_print_verification = mocker.patch('webcomix.main.print_verification')
 
     result = runner.invoke(main.custom, [
         "--comic_name=foo", "--start_url=url", "--next_page_xpath=next_page",
         "--image_xpath=image"
     ], "yes")
     assert result.exit_code == 0
-    assert result.output.strip() == "\n".join([
-        "Verified", "Printed",
-        "Verify that the links above are correct before proceeding.",
-        "Are you sure you want to proceed? [y/N]: yes", "foo"
-    ])
+    assert mock_download.call_count == 1
+    assert mock_verify_xpath.call_count == 1
+    assert mock_print_verification.call_count == 1
 
 
-def test_custom_make_cbz(monkeypatch):
+def test_custom_make_cbz(mocker):
     runner = CliRunner()
-    monkeypatch.setattr(Comic, "download", mock_download)
-    monkeypatch.setattr(Comic, "verify_xpath", mock_verify_xpath)
-    monkeypatch.setattr(main, "print_verification", mock_print_verification)
-    monkeypatch.setattr(Comic, "make_cbz", mock_make_cbz)
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
+    mock_verify_xpath = mocker.patch('webcomix.comic.Comic.verify_xpath')
+    mock_print_verification = mocker.patch('webcomix.main.print_verification')
+    mock_make_cbz = mocker.patch('webcomix.comic.Comic.make_cbz')
 
     result = runner.invoke(main.custom, [
         "--comic_name=foo", "--start_url=url", "--next_page_xpath=next_page",
         "--image_xpath=image", "--cbz"
     ], "y")
     assert result.exit_code == 0
-    assert result.output.strip() == "\n".join([
-        "Verified", "Printed",
-        "Verify that the links above are correct before proceeding.",
-        "Are you sure you want to proceed? [y/N]: y", "foo", ".cbz created"
-    ])
+    assert mock_download.call_count == 1
+    assert mock_verify_xpath.call_count == 1
+    assert mock_print_verification.call_count == 1
+    assert mock_make_cbz.call_count == 1
 
 
-def mock_discovery(url):
-    return Comic("url", "next_page", "comic_image")
-
-
-def test_search(monkeypatch):
+def test_search(mocker):
     runner = CliRunner()
-    main.discovery = mock_discovery
-    monkeypatch.setattr(Comic, "download", mock_download)
-    monkeypatch.setattr(Comic, "verify_xpath", mock_verify_xpath)
-    monkeypatch.setattr(main, "print_verification", mock_print_verification)
+    mock_discovery = mocker.patch(
+        'webcomix.main.discovery',
+        return_value=Comic("url", "next_page", "comic_image"))
+    mock_download = mocker.patch('webcomix.comic.Comic.download')
+    mock_verify_xpath = mocker.patch('webcomix.comic.Comic.verify_xpath')
+    mock_print_verification = mocker.patch('webcomix.main.print_verification')
 
     result = runner.invoke(main.search, ["foo", "--start_url=good"], "y")
     assert result.exit_code == 0
-    assert result.output.strip() == "\n".join([
-        "Verified", "Printed",
-        "Verify that the links above are correct before proceeding.",
-        "Are you sure you want to proceed? [y/N]: y", "foo"
-    ])
+    assert mock_discovery.call_count == 1
+    assert mock_download.call_count == 1
+    assert mock_verify_xpath.call_count == 1
+    assert mock_print_verification.call_count == 1

--- a/webcomix/tests/test_misc.py
+++ b/webcomix/tests/test_misc.py
@@ -1,7 +1,10 @@
+import pytest
+
 from webcomix.comic import Comic
 from webcomix.supported_comics import supported_comics
 
 
+@pytest.mark.slow
 def test_supported_comics():
     for comic_name, comic_info in supported_comics.items():
         first_pages = Comic.verify_xpath(*comic_info)


### PR DESCRIPTION
This should improve performance when scraping webcomics, according to some of the benchmarks I've made.

For example, when downloading the `xkcd` comic, it took me 4m58 when using scrapy instead of 7m25 with the current algorithm on master. With the JL8 comic, it took me 1m17 when using scrapy instead of 4m27 with the current algorithm on master.

To make sure this is production-ready, I will make sure it can be downloaded through `pip` for users without any problems.