### PR TITLE
Set windows_expand_args to False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pre-commit = "^2.15.0"
 black = "^24.3.0"
 
 [tool.poetry.scripts]
-webcomix = "webcomix.cli:cli"
+webcomix = "webcomix.cli:main"
 
 [build-system]
 requires = ["poetry>=1.2.0"]

--- a/webcomix/cli.py
+++ b/webcomix/cli.py
@@ -9,7 +9,7 @@ from webcomix.supported_comics import supported_comics
 from webcomix.docker import DockerManager
 
 
-@click.group(windows_expand_args=False)
+@click.group()
 @click.version_option()
 def cli():
     pass
@@ -288,6 +288,9 @@ def custom(
         if yes or click.confirm("Are you sure you want to proceed?"):
             download_webcomic(comic, cbz)
 
+
+def main():
+    cli(windows_expand_args=False)
 
 def print_verification(validation):
     """

--- a/webcomix/cli.py
+++ b/webcomix/cli.py
@@ -9,7 +9,7 @@ from webcomix.supported_comics import supported_comics
 from webcomix.docker import DockerManager
 
 
-@click.group()
+@click.group(windows_expand_args=False)
 @click.version_option()
 def cli():
     pass


### PR DESCRIPTION
Since we don't use any glob pattern (nor any environment variable really), we shouldn't need expand on Windows. This has caused problem for us when expanding arguments using Windows (See #101)

This should solve this issue.