### PR TITLE
added exception handing & query parameter parsing for comics where fi…

### DIFF
--- a/webcomix/comic.py
+++ b/webcomix/comic.py
@@ -192,8 +192,42 @@ class Comic:
             # No file extension (only dot in url is domain name)
             return str(page)
 
-        parsed_filepath = urlparse(url).path
-        file_extension = parsed_filepath[parsed_filepath.rindex(".") :]
+        """
+        Checking if we have the extension in the URL path or in a query parameter
+        Some comics use query parameters to identify content
+        This can cause an exception in rindex as the path won't have the file nor extension
+        Thus, we try the path first, followed by the query broken down into component parameters
+        """
+        file_extension = ""
+        parts = urlparse(url)
+
+        try:
+            parsed_filepath = parts.path
+            file_extension = parsed_filepath[parsed_filepath.rindex(".") :]
+        except:
+            if "?" in url:
+                if "&" in parts.query:
+                    parsed_queries = parts.query.split("&")
+                    for current_query in parsed_queries:
+                        try:
+                            file_extension = current_query[current_query.rindex(".") :]
+                            break
+                        except:
+                            # nothing, loop again
+                            dummy_var = ""
+                else:
+                    try:
+                        file_extension = parts.query[parts.query.rindex(".") :]
+                    except:
+                        print(
+                            "File extension unknown; setting as '.unknown' to preserve data"
+                        )
+                        file_extension = ".unknown"
+            else:
+                # worst case we can't identify the extension, setting 'unknown' to allow saving file for evaluation
+                print("File extension unknown; setting as '.unknown' to preserve data")
+                file_extension = ".unknown"
+
         if title_present:
             return "{}-{}{}".format(comic_name, page, file_extension)
         else:

--- a/webcomix/supported_comics.py
+++ b/webcomix/supported_comics.py
@@ -257,6 +257,18 @@ supported_comics = {
         "name": "JackRabbit",
         "start_url": "https://jackrabbit.thecomicseries.com/comics/1/#content-start",
         "comic_image_selector": "//img[@id='comicimage']/@src",
-        "next_page_selector": "//a[contains(@rel, 'next')]//@href",
+        "next_page_selector": "//a[img[contains(@rel, 'next')]]//@href",
+    },
+    "InkBlot": {
+        "name": "InkBlot",
+        "start_url": "https://www.inkboltcomic.com/index.php?page=1",
+        "comic_image_selector": "//img[@alt='Comic Image']/@src",
+        "next_page_selector": "//a[img[@alt='Next Page']]//@href",
+    },
+    "QuantumVibe": {
+        "name": "QuantumVibe",
+        "start_url": "https://quantumvibe.com/strip?page=1",
+        "comic_image_selector": "//a[contains(@href, 'strip?page=')]//img[contains(@src, 'disppage')]/@src",
+        "next_page_selector": "//a[img[contains(@src, 'nav/NextStrip2.gif')]]/@href",
     },
 }


### PR DESCRIPTION
#### Fix PR for Issue #110 

Whilst adding "Quantum Vibe" I found a bug in the URL parser implementation within[ comic.py](https://github.com/J-CPelletier/webcomix/blob/master/webcomix/comic.py#L195)

```
parsed_filepath = urlparse(url).path
file_extension = parsed_filepath[parsed_filepath.rindex(".") :]
```
This will throw a ValueError exception when the image is identified within a query parameter rather than a URL path.
Example that throws exception from "Quantum Vibe"
`https://quantumvibe.com/disppageV3?story=qv&file=/simages/qv/qv1-001.jpg`

To remedy this, I implemented exception handling and query parsing to identify where the filename/extension lives within the full URL. If none can be identified, it will gracefully save the file with a `.unknown` extension to at least preserve the data and allow later recovery through a rename operation when the file type is known. I could probably implement some MIME detection here in that scenario, but have not yet.

Sample config for Quantum Vibe for testing:
```
    "QuantumVibe": {
        "name": "QuantumVibe",
        "start_url": "https://quantumvibe.com/strip?page=1",
        "comic_image_selector": "//a[contains(@href, 'strip?page=')]//img[contains(@src, 'disppage')]/@src",
        "next_page_selector": "//a[img[contains(@src, 'nav/NextStrip2.gif')]]/@href",
    },
```

Limitations with this draft PR:
- Does not gracefully handle an edge case where the path has an extension but it's not the image extension which is located deeper in the URL ( example: `something.php?comic=somecomic&page=pagexyz.jpg`)
- Despite logic changes leaving the version number change to package maintainer.