### PR TITLE
JackRabbit in supported_comics

### DIFF
--- a/webcomix/supported_comics.py
+++ b/webcomix/supported_comics.py
@@ -257,6 +257,6 @@ supported_comics = {
         "name": "JackRabbit",
         "start_url": "https://jackrabbit.thecomicseries.com/comics/1/#content-start",
         "comic_image_selector": "//img[@id='comicimage']/@src",
-        "next_page_selector": "//a[contains(@rel, 'next')]//@href",
+        "next_page_selector": "//a[@rel='next']//@href",
     },
 }


### PR DESCRIPTION
I accepted the change with jackrabbit in the last PR and trying again it's not running.

I swapped it to an element comparison vs a contains() in the next page xpath and it seems to be running. It's possible there was another element in the page that was passing the rel contains check and going back to the same image, making Scrapy think it was getting repeat content and exiting.

